### PR TITLE
Fix file type detection for uploads

### DIFF
--- a/packages/server/src/services/documentstore/index.ts
+++ b/packages/server/src/services/documentstore/index.ts
@@ -1454,7 +1454,7 @@ const upsertDocStoreMiddleware = async (
             if (fileInputFieldFromExt !== 'txtFile') {
                 fileInputField = fileInputFieldFromExt
             } else if (fileInputFieldFromMimeType !== 'txtFile') {
-                fileInputField = fileInputFieldFromExt
+                fileInputField = fileInputFieldFromMimeType
             }
 
             if (loaderId === 'unstructuredFileLoader') {

--- a/packages/server/src/utils/buildChatflow.ts
+++ b/packages/server/src/utils/buildChatflow.ts
@@ -178,7 +178,7 @@ export const utilBuildChatflow = async (req: Request, isInternal: boolean = fals
                 if (fileInputFieldFromExt !== 'txtFile') {
                     fileInputField = fileInputFieldFromExt
                 } else if (fileInputFieldFromMimeType !== 'txtFile') {
-                    fileInputField = fileInputFieldFromExt
+                    fileInputField = fileInputFieldFromMimeType
                 }
 
                 if (overrideConfig[fileInputField]) {

--- a/packages/server/src/utils/createAttachment.ts
+++ b/packages/server/src/utils/createAttachment.ts
@@ -60,7 +60,7 @@ export const createFileAttachment = async (req: Request) => {
             if (fileInputFieldFromExt !== 'txtFile') {
                 fileInputField = fileInputFieldFromExt
             } else if (fileInputFieldFromMimeType !== 'txtFile') {
-                fileInputField = fileInputFieldFromExt
+                fileInputField = fileInputFieldFromMimeType
             }
 
             fs.unlinkSync(file.path)

--- a/packages/server/src/utils/upsertVector.ts
+++ b/packages/server/src/utils/upsertVector.ts
@@ -73,7 +73,7 @@ export const upsertVector = async (req: Request, isInternal: boolean = false) =>
                 if (fileInputFieldFromExt !== 'txtFile') {
                     fileInputField = fileInputFieldFromExt
                 } else if (fileInputFieldFromMimeType !== 'txtFile') {
-                    fileInputField = fileInputFieldFromExt
+                    fileInputField = fileInputFieldFromMimeType
                 }
 
                 if (overrideConfig[fileInputField]) {


### PR DESCRIPTION
## Summary
- correct file field selection when file extension is default

## Testing
- `pnpm lint` *(fails: ESLint couldn't find configuration)*
- `pnpm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8cef70688321af96b57a3b8fed50